### PR TITLE
Github actions quick fix to stop CI running when it shouldn't

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -3,6 +3,8 @@ name: Deploy Jekyll site to Pages
 
 on:
   push:
+    branches:
+        - main
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
This fixes the issue of branches other than `main` triggering a CI build on push, which results in the following error:

```
Branch <XYZ> is not allowed to deploy to github-pages due to environment protection rules.
```

With this fix builds should only be triggered either on pushes to `main` or manual run :)